### PR TITLE
Fix/adjust remover behaviors

### DIFF
--- a/lib/src/main/kotlin/nolambda/stream/cleaningservice/remover/AbstractRemover.kt
+++ b/lib/src/main/kotlin/nolambda/stream/cleaningservice/remover/AbstractRemover.kt
@@ -36,7 +36,7 @@ abstract class AbstractRemover(
             val stringBuilder = StringBuilder()
 
             moduleSrcDirs.map { File(it) }
-                .filter { it.exists() }
+                .filter { it.exists() && it.isDirectory.not() }
                 .forEach { srcDirFile ->
                     srcDirFile.listFiles { _, name ->
                         FILE_TYPE_FILTER.matches(name)

--- a/lib/src/main/kotlin/nolambda/stream/cleaningservice/report/ReportParser.kt
+++ b/lib/src/main/kotlin/nolambda/stream/cleaningservice/report/ReportParser.kt
@@ -1,5 +1,8 @@
 package nolambda.stream.cleaningservice.report
 
+import nolambda.stream.cleaningservice.remover.RemoverFactory
+import nolambda.stream.cleaningservice.remover.file.FileRemover
+import nolambda.stream.cleaningservice.remover.xml.XmlValueRemover
 import java.io.File
 
 interface ReportParser {
@@ -21,6 +24,8 @@ class DefaultReportParser(
     private val projectDir: File,
     private val reportDir: File
 ) : ReportParser {
+
+    private val allRemovers by lazy { RemoverFactory.getAllRemovers() }
 
     override fun parse(): List<ReportParser.DeleteAction> {
         val reportFiles = reportDir.listFiles().orEmpty()
@@ -49,9 +54,10 @@ class DefaultReportParser(
     }
 
     private fun identifierToRemover(identifier: String): ReportParser.RemoverType {
-        return when (identifier) {
-            "layout" -> ReportParser.RemoverType.FILE
-            "string" -> ReportParser.RemoverType.XML
+        val remover = allRemovers.find { it.resourceName == identifier }
+        return when (remover) {
+            is FileRemover -> ReportParser.RemoverType.FILE
+            is XmlValueRemover -> ReportParser.RemoverType.XML
             else -> error(
                 "There's no remover with identifier \"$identifier\". " +
                     "Please don't change the result name because the remover rely on the naming convention"

--- a/lib/src/test/kotlin/nolambda/stream/cleaningservice/plugin/components/CleaningFromReportSpec.kt
+++ b/lib/src/test/kotlin/nolambda/stream/cleaningservice/plugin/components/CleaningFromReportSpec.kt
@@ -28,7 +28,8 @@ class CleaningFromReportSpec : StringSpec({
 
         val removedFiles = listOf(
             "myawesomemodule1/src/main/res/values/strings-unused.xml",
-            "myawesomemodule2/src/main/res/layout/acitivty_unused.xml"
+            "myawesomemodule2/src/main/res/layout/acitivty_unused.xml",
+            "myawesomemodule2/src/main/res/drawable/ic_unused.xml"
         )
 
         val removedItemFiles = listOf(
@@ -36,6 +37,7 @@ class CleaningFromReportSpec : StringSpec({
         )
 
         removedFiles.forEach {
+            println("Check if file exists for $it")
             File(sampleDir, it).exists() shouldBe false
         }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,6 +20,7 @@ cleaningService {
     remover {
         only(
                 "nolambda.stream.cleaningservice.remover.file.LayoutFileRemover",
+                "nolambda.stream.cleaningservice.remover.file.DrawableFileRemover",
                 "nolambda.stream.cleaningservice.remover.xml.StringXmlRemover"
         )
     }

--- a/sample/myawesomemodule2/src/main/res/drawable/ic_unused.xml
+++ b/sample/myawesomemodule2/src/main/res/drawable/ic_unused.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#008577"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M9,0L9,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,0L19,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M29,0L29,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M39,0L39,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M49,0L49,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M59,0L59,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M69,0L69,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M79,0L79,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M89,0L89,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M99,0L99,108"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,9L108,9"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,19L108,19"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,29L108,29"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,39L108,39"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,49L108,49"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,59L108,59"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,69L108,69"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,79L108,79"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,89L108,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,99L108,99"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,29L89,29"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,39L89,39"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,49L89,49"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,59L89,59"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,69L89,69"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,79L89,79"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M29,19L29,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M39,19L39,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M49,19L49,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M59,19L59,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M69,19L69,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M79,19L79,89"
+        android:strokeWidth="0.8"
+        android:strokeColor="#33FFFFFF" />
+</vector>


### PR DESCRIPTION
1. Only check for non-directory files outside `src/`
2. Report parser identifier lookup changed from manual to lookup from `RemoverFactory.getAllRemovers()`
3. Add unused drawable sample